### PR TITLE
Update workflow to use repo-level variable for IMAGE_NAME

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ secrets.IMAGE_NAME || 'DOCKERHUB_USERNAME/trivexer' }}
+            ${{ vars.IMAGE_NAME || 'DOCKERHUB_USERNAME/trivexer' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -56,5 +56,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ secrets.IMAGE_NAME || 'DOCKERHUB_USERNAME/trivexer' }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.IMAGE_NAME || 'DOCKERHUB_USERNAME/trivexer' }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ vars.IMAGE_NAME || 'DOCKERHUB_USERNAME/trivexer' }}:buildcache
+          cache-to: type=registry,ref=${{ vars.IMAGE_NAME || 'DOCKERHUB_USERNAME/trivexer' }}:buildcache,mode=max


### PR DESCRIPTION
Updates release workflow to use vars.IMAGE_NAME instead of secrets.IMAGE_NAME to align with organization-level secrets configuration.